### PR TITLE
[✨Feat/#11] 카테고리 리스트 조회 API 구현

### DIFF
--- a/sopkathon/src/main/java/org/sopt/sopkathon/controller/CategoryController.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/controller/CategoryController.java
@@ -2,12 +2,16 @@ package org.sopt.sopkathon.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.sopkathon.dto.request.CategoryRequest;
+import org.sopt.sopkathon.dto.response.CategoryResponse;
 import org.sopt.sopkathon.exception.dto.SuccessResponse;
 import org.sopt.sopkathon.service.CategoryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +24,11 @@ public class CategoryController {
     public ResponseEntity<SuccessResponse> addCategory(CategoryRequest categoryRequest) {
         SuccessResponse response = categoryService.addCategory(categoryRequest);
         return ResponseEntity.status(201).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<CategoryResponse>>> getCategories() {
+        SuccessResponse<List<CategoryResponse>> response = categoryService.getCategories();
+        return ResponseEntity.ok(response);
     }
 }

--- a/sopkathon/src/main/java/org/sopt/sopkathon/dto/response/CategoryResponse.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/dto/response/CategoryResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.sopkathon.dto.response;
+
+public record CategoryResponse(
+        Long categoryId,
+        String categoryName,
+        int wordsNumber
+) {
+}

--- a/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-    SUCCESS_CREATE_CATEGORY(201, true, "카테고리를 성공적으로 추가하였습니다.")
+    SUCCESS_CREATE_CATEGORY(201, true, "카테고리를 성공적으로 추가하였습니다."),
+    SUCCESS_GET_CATEGORIES(200, true, "카테고리 리스트 조회 성공하였습니다.")
     ;
 
     private final int status;

--- a/sopkathon/src/main/java/org/sopt/sopkathon/service/CategoryService.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/service/CategoryService.java
@@ -3,11 +3,16 @@ package org.sopt.sopkathon.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.sopkathon.domain.Category;
 import org.sopt.sopkathon.dto.request.CategoryRequest;
+import org.sopt.sopkathon.dto.response.CategoryResponse;
 import org.sopt.sopkathon.exception.dto.SuccessResponse;
 import org.sopt.sopkathon.exception.enums.SuccessMessage;
 import org.sopt.sopkathon.repository.CategoryRepository;
+import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,4 +27,16 @@ public class CategoryService {
         categoryRepository.save(category);
         return SuccessResponse.of(SuccessMessage.SUCCESS_CREATE_CATEGORY);
     }
+
+    public SuccessResponse<List<CategoryResponse>> getCategories(){
+        List<CategoryResponse> categoryResponses = categoryRepository.findAll().stream()
+                .map(category -> new CategoryResponse(
+                        category.getCategoryId(),
+                        category.getCategoryName(),
+                        category.getWordList().size()))
+                .collect(Collectors.toList());
+
+        return SuccessResponse.of(SuccessMessage.SUCCESS_GET_CATEGORIES, categoryResponses);
+    }
+
 }


### PR DESCRIPTION
## 📄 Work Description
카테고리(단어장) 리스트를 조회하는 API 구현

## ⚙️ ISSUE
- closed: #11 


## 📷 Screenshot
<!-- 동영상, 사진, 로그 등등 -->
<!-- ex) 큐알 성공 이미지, 스웨거, 포스트맨 등 -->
<img width="1442" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/150939763/394d408a-19b0-450d-ae60-4ebd5801f24c">
<img width="1434" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/150939763/3be6571c-83f2-4bfa-b4c0-cac18a8899ad">



## 💬 To Reviewers
<!-- 리뷰어들에게 하고 싶은 말 -->
카테고리를 단순히 리스트로 조회하는 것이라 코드에 큰 변경사항은 없습니다..!
처음부터 user를 고려하지 않고 category 리스트를 모두 보여줘야하기 때문에 추가적인 예외처리는 생략하고 성공응답만 주었습니다..!

코드에 관해서 개선할 사항이 있거나, 모르는 부분이 있다면 언제든지 질문주세요:)

## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크) -->
