### PR TITLE
[✨Feat/#13] 새로운 단어 추가 API 구현

### DIFF
--- a/sopkathon/src/main/java/org/sopt/sopkathon/controller/WordController.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/controller/WordController.java
@@ -1,0 +1,24 @@
+package org.sopt.sopkathon.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.sopkathon.dto.request.WordRequest;
+import org.sopt.sopkathon.exception.dto.SuccessResponse;
+import org.sopt.sopkathon.service.WordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories")
+public class WordController {
+
+    private final WordService wordService;
+
+    @PostMapping("/{category_id}/words/input")
+    public ResponseEntity<SuccessResponse> addWord(
+            @PathVariable("category_id") Long category_id,
+            @RequestBody WordRequest wordRequest) {
+        SuccessResponse response = wordService.addWord(category_id, wordRequest);
+        return ResponseEntity.status(201).body(response);
+    }
+}

--- a/sopkathon/src/main/java/org/sopt/sopkathon/dto/request/WordRequest.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/dto/request/WordRequest.java
@@ -1,0 +1,8 @@
+package org.sopt.sopkathon.dto.request;
+
+public record WordRequest(
+
+        String vocabulary,
+        String meaning
+) {
+}

--- a/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/ErrorMessage.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/ErrorMessage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
 
+    NOT_FOUND_CATEGORY(404, "해당 카테고리가 존재하지 않습니다.")
     ;
     private final int status;
     private final String message;

--- a/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum SuccessMessage {
 
     SUCCESS_CREATE_CATEGORY(201, true, "카테고리를 성공적으로 추가하였습니다."),
-    SUCCESS_GET_CATEGORIES(200, true, "카테고리 리스트 조회 성공하였습니다.")
+    SUCCESS_GET_CATEGORIES(200, true, "카테고리 리스트 조회 성공하였습니다."),
+    SUCCESS_CREATE_WORD(201, true, "단어를 성공적으로 추가하였습니다."),
     ;
 
     private final int status;

--- a/sopkathon/src/main/java/org/sopt/sopkathon/repository/WordRepository.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/repository/WordRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.sopkathon.repository;
+
+import org.sopt.sopkathon.domain.Word;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WordRepository extends JpaRepository<Word, Long> {
+}

--- a/sopkathon/src/main/java/org/sopt/sopkathon/service/WordService.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/service/WordService.java
@@ -1,0 +1,35 @@
+package org.sopt.sopkathon.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.sopkathon.domain.Category;
+import org.sopt.sopkathon.domain.Word;
+import org.sopt.sopkathon.dto.request.WordRequest;
+import org.sopt.sopkathon.exception.CustomException;
+import org.sopt.sopkathon.exception.dto.SuccessResponse;
+import org.sopt.sopkathon.exception.enums.SuccessMessage;
+import org.sopt.sopkathon.repository.CategoryRepository;
+import org.sopt.sopkathon.repository.WordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.sopt.sopkathon.exception.enums.ErrorMessage.NOT_FOUND_CATEGORY;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WordService {
+
+    private final CategoryRepository categoryRepository;
+    private final WordRepository wordRepository;
+
+    @Transactional
+    public SuccessResponse addWord(Long categoryId, WordRequest wordRequest) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_CATEGORY));
+
+        Word word = Word.createWord(category, wordRequest.vocabulary(), wordRequest.meaning(), 0);
+        wordRepository.save(word);
+
+        return SuccessResponse.of(SuccessMessage.SUCCESS_CREATE_WORD);
+    }
+}


### PR DESCRIPTION
## 📄 Work Description
<!-- 설명 -->
카테고리에 새로운 단어의 원문과 뜻을 추가하는 API 구현

## ⚙️ ISSUE
- closed: #13 


## 📷 Screenshot
<!-- 동영상, 사진, 로그 등등 -->
<!-- ex) 큐알 성공 이미지, 스웨거, 포스트맨 등 -->
- Swagger 201
<img width="1459" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/150939763/51e43bd6-55d9-4d2e-a835-e8e8c8e837a7">
<img width="1436" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/150939763/5eaa5b75-457f-4dff-bf77-10542e7982e9">

<br/>
- Swagger 404 (존재하지 않는 카테고리에 단어를 추가하려 할 경우 에러 발생)
<img width="1457" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/150939763/5c6e4b77-e63c-4bb8-9911-14d5650c4119">



## 💬 To Reviewers
<!-- 리뷰어들에게 하고 싶은 말 -->
존재하지 않는 카테고리에 단어를 추가하려 할 경우, 404(Not Found)가 뜨도록 구현했습니다.
category_id를 RequestHeader로 요청받아 응답을 처리하도록 구현하였습니다!!

코드에 잘못된 부분이나 개선할 부분이 있다면 언제든지 질문주세요:)

## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크) -->
