### PR TITLE
[✨Feat/#14] 단어 리스트 조회 API 구현

### DIFF
--- a/sopkathon/src/main/java/org/sopt/sopkathon/controller/MemorizedWordController.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/controller/MemorizedWordController.java
@@ -1,0 +1,25 @@
+package org.sopt.sopkathon.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.sopkathon.dto.response.MemorizedWordResponse;
+import org.sopt.sopkathon.exception.dto.SuccessResponse;
+import org.sopt.sopkathon.service.MemorizedWordService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/memorized-words")
+public class MemorizedWordController {
+
+    private final MemorizedWordService memorizedWordService;
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<MemorizedWordResponse>>> getMemorizedWords() {
+        SuccessResponse<List<MemorizedWordResponse>> response = memorizedWordService.getMemorizedWords();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/sopkathon/src/main/java/org/sopt/sopkathon/dto/response/MemorizedWordResponse.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/dto/response/MemorizedWordResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.sopkathon.dto.response;
+
+public record MemorizedWordResponse(
+        Long memorizedWordId,
+        Long categoryId,
+        String memorizedVocabulary,
+        String memorizedMeaning
+) {
+}

--- a/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
@@ -10,8 +10,7 @@ public enum SuccessMessage {
     SUCCESS_CREATE_CATEGORY(201, true, "카테고리를 성공적으로 추가하였습니다."),
     SUCCESS_GET_CATEGORIES(200, true, "카테고리 리스트 조회 성공하였습니다."),
     SUCCESS_CREATE_WORD(201, true, "단어를 성공적으로 추가하였습니다."),
-    ;
-
+    SUCCESS_GET_MEMORIZEDWORDS(200, true, "외운 단어 리스트 조회를 성공하였습니다.");
     private final int status;
     private final boolean success;
     private final String message;

--- a/sopkathon/src/main/java/org/sopt/sopkathon/repository/MemorizedWordRepository.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/repository/MemorizedWordRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.sopkathon.repository;
+
+import org.sopt.sopkathon.domain.MemorizedWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemorizedWordRepository extends JpaRepository<MemorizedWord, Long> {
+}

--- a/sopkathon/src/main/java/org/sopt/sopkathon/service/MemorizedWordService.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/service/MemorizedWordService.java
@@ -1,0 +1,30 @@
+package org.sopt.sopkathon.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.sopkathon.dto.response.MemorizedWordResponse;
+import org.sopt.sopkathon.exception.dto.SuccessResponse;
+import org.sopt.sopkathon.exception.enums.SuccessMessage;
+import org.sopt.sopkathon.repository.MemorizedWordRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemorizedWordService {
+
+    private final MemorizedWordRepository memorizedWordRepository;
+
+    public SuccessResponse<List<MemorizedWordResponse>> getMemorizedWords() {
+        List<MemorizedWordResponse> memorizedWordResponses = memorizedWordRepository.findAll().stream()
+                .map(memorizedWord -> new MemorizedWordResponse(
+                        memorizedWord.getMemorizedWordId(),
+                        memorizedWord.getCategory().getCategoryId(),
+                        memorizedWord.getMemorizedVocabulary(),
+                        memorizedWord.getMemorizedMeaning()))
+                .collect(Collectors.toList());
+
+        return SuccessResponse.of(SuccessMessage.SUCCESS_GET_MEMORIZEDWORDS, memorizedWordResponses);
+    }
+
+}


### PR DESCRIPTION
## 📄 Work Description
<!-- 설명 -->
카테고리 상관없이 외운 단어 리스트를 모두 조회하는 API 구현

## ⚙️ ISSUE
- closed: #14 


## 📷 Screenshot
<!-- 동영상, 사진, 로그 등등 -->
<!-- ex) 큐알 성공 이미지, 스웨거, 포스트맨 등 -->
<img width="1440" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/81475587/c69f0c0e-cbfb-4b9c-a5fd-7b152c701ca7">
<img width="1432" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/81475587/7667993c-1801-41a0-8bd8-8ec642fb7163">


## 💬 To Reviewers
<!-- 리뷰어들에게 하고 싶은 말 -->
조금만 더 힘냅시다 화이팅 !!!!!

## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크) -->
