### PR TITLE
[✨Feat/#18] 특정 단어 클릭 시 조회 API 구현

### DIFF
--- a/sopkathon/src/main/java/org/sopt/sopkathon/controller/WordController.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/controller/WordController.java
@@ -7,7 +7,12 @@ import org.sopt.sopkathon.dto.response.WordResponse;
 import org.sopt.sopkathon.exception.dto.SuccessResponse;
 import org.sopt.sopkathon.service.WordService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -33,5 +38,13 @@ public class WordController {
             @PathVariable("category_id") Long category_id) {
                 SuccessResponse<List<WordResponse>> response = wordService.getWords(category_id);
                 return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{category_id}/words/{word_id}")
+    public ResponseEntity<SuccessResponse> getWord(
+            @PathVariable("category_id") Long category_id,
+            @PathVariable("word_id") Long word_id) {
+        SuccessResponse response = wordService.getWord(category_id, word_id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/sopkathon/src/main/java/org/sopt/sopkathon/domain/Word.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/domain/Word.java
@@ -1,15 +1,24 @@
 package org.sopt.sopkathon.domain;
 
-import jakarta.persistence.*;
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import static lombok.AccessLevel.PRIVATE;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Word {
 
@@ -30,16 +39,15 @@ public class Word {
     private int clickCount;
 
     @Builder(access = PRIVATE)
-    private Word(final Category category, final String vocabulary, final String meaning, final int clickCount)
-    {
+    private Word(final Category category, final String vocabulary, final String meaning, final int clickCount) {
         this.category = category;
         this.vocabulary = vocabulary;
         this.meaning = meaning;
         this.clickCount = clickCount;
     }
 
-    public static Word createWord(final Category category, final String vocabulary, final String meaning, final int clickCount)
-    {
+    public static Word createWord(final Category category, final String vocabulary, final String meaning,
+                                  final int clickCount) {
         return Word.builder()
                 .category(category)
                 .vocabulary(vocabulary)

--- a/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/ErrorMessage.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/ErrorMessage.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
 
-    NOT_FOUND_CATEGORY(404, "해당 카테고리가 존재하지 않습니다.")
-    ;
+    NOT_FOUND_CATEGORY(404, "해당 카테고리가 존재하지 않습니다."),
+    NOT_FOUND_WORD(404, "해당 단어가 존재하지 않습니다.");
+    
     private final int status;
     private final String message;
 }

--- a/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/exception/enums/SuccessMessage.java
@@ -11,8 +11,8 @@ public enum SuccessMessage {
     SUCCESS_GET_CATEGORIES(200, true, "카테고리 리스트 조회를 성공하였습니다."),
     SUCCESS_CREATE_WORD(201, true, "단어를 성공적으로 추가하였습니다."),
     SUCCESS_GET_WORDS(200, true, "단어 리스트 조회를 성공하였습니다."),
-    SUCCESS_GET_MEMORIZEDWORDS(200, true, "외운 단어 리스트 조회를 성공하였습니다.")
-    ;
+    SUCCESS_GET_MEMORIZED_WORDS(200, true, "외운 단어 리스트 조회를 성공하였습니다."),
+    SUCCESS_GET_WORD(200, true, "특정 단어 조회를 성공하였습니다.");
     private final int status;
     private final boolean success;
     private final String message;

--- a/sopkathon/src/main/java/org/sopt/sopkathon/repository/WordRepository.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/repository/WordRepository.java
@@ -1,14 +1,16 @@
 package org.sopt.sopkathon.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.sopt.sopkathon.domain.Category;
 import org.sopt.sopkathon.domain.Word;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface WordRepository extends JpaRepository<Word, Long> {
 
     List<Word> findAllByCategory(Category category);
 
     List<Word> findAllByCategoryAndClickCountLessThan(Category category, int maxClickCount);
+
+    Optional<Word> findByCategoryCategoryIdAndWordId(Long categoryId, Long wordId);
 }

--- a/sopkathon/src/main/java/org/sopt/sopkathon/service/MemorizedWordService.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/service/MemorizedWordService.java
@@ -24,7 +24,7 @@ public class MemorizedWordService {
                         memorizedWord.getMemorizedMeaning()))
                 .collect(Collectors.toList());
 
-        return SuccessResponse.of(SuccessMessage.SUCCESS_GET_MEMORIZEDWORDS, memorizedWordResponses);
+        return SuccessResponse.of(SuccessMessage.SUCCESS_GET_MEMORIZED_WORDS, memorizedWordResponses);
     }
 
 }

--- a/sopkathon/src/main/java/org/sopt/sopkathon/service/WordService.java
+++ b/sopkathon/src/main/java/org/sopt/sopkathon/service/WordService.java
@@ -1,22 +1,24 @@
 package org.sopt.sopkathon.service;
 
+import static org.sopt.sopkathon.exception.enums.ErrorMessage.NOT_FOUND_CATEGORY;
+
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.sopkathon.domain.Category;
+import org.sopt.sopkathon.domain.MemorizedWord;
 import org.sopt.sopkathon.domain.Word;
 import org.sopt.sopkathon.dto.request.WordRequest;
 import org.sopt.sopkathon.dto.response.WordResponse;
 import org.sopt.sopkathon.exception.CustomException;
 import org.sopt.sopkathon.exception.dto.SuccessResponse;
+import org.sopt.sopkathon.exception.enums.ErrorMessage;
 import org.sopt.sopkathon.exception.enums.SuccessMessage;
 import org.sopt.sopkathon.repository.CategoryRepository;
+import org.sopt.sopkathon.repository.MemorizedWordRepository;
 import org.sopt.sopkathon.repository.WordRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.sopt.sopkathon.exception.enums.ErrorMessage.NOT_FOUND_CATEGORY;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +27,7 @@ public class WordService {
 
     private final CategoryRepository categoryRepository;
     private final WordRepository wordRepository;
+    private final MemorizedWordRepository memorizedWordRepository;
 
     @Transactional
     public SuccessResponse addWord(Long categoryId, WordRequest wordRequest) {
@@ -37,7 +40,7 @@ public class WordService {
         return SuccessResponse.of(SuccessMessage.SUCCESS_CREATE_WORD);
     }
 
-    public SuccessResponse<List<WordResponse>> getWords(Long categoryId){
+    public SuccessResponse<List<WordResponse>> getWords(Long categoryId) {
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_CATEGORY));
 
@@ -47,5 +50,28 @@ public class WordService {
                 .collect(Collectors.toList());
 
         return SuccessResponse.of(SuccessMessage.SUCCESS_GET_WORDS, wordResponses);
+    }
+
+    @Transactional
+    public SuccessResponse<WordResponse> getWord(Long categoryId, Long wordId) {
+        Word word = wordRepository.findByCategoryCategoryIdAndWordId(categoryId, wordId)
+                .orElseThrow(() -> new CustomException((ErrorMessage.NOT_FOUND_WORD)));
+
+        if (word.getClickCount() >= 6) {
+            MemorizedWord memorizedWord = MemorizedWord.createMemorizedWord(word.getCategory(), word.getVocabulary(),
+                    word.getMeaning());
+            memorizedWordRepository.save(memorizedWord);
+            word.setClickCount(word.getClickCount() + 1);
+            WordResponse wordResponse = WordResponse.of(word);
+            wordRepository.delete(word);
+            return SuccessResponse.of(SuccessMessage.SUCCESS_GET_WORD, wordResponse);
+        } else {
+            word.setClickCount(word.getClickCount() + 1);
+        }
+
+        WordResponse wordResponse = WordResponse.of(word);
+        wordRepository.save(word);
+
+        return SuccessResponse.of(SuccessMessage.SUCCESS_GET_WORD, wordResponse);
     }
 }


### PR DESCRIPTION
## 📄 Work Description
<!-- 설명 -->
카테고리 상관없이 외운 단어 리스트를 모두 조회하는 API 구현


## ⚙️ ISSUE
- closed: #18 


## 📷 Screenshot
<!-- 동영상, 사진, 로그 등등 -->
<!-- ex) 큐알 성공 이미지, 스웨거, 포스트맨 등 -->
<img width="1438" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/81475587/cce40d5e-858c-43a3-9a16-463d27449ce7">
<img width="1437" alt="image" src="https://github.com/SOPKATHON-iOS-TEAM4/SERVER/assets/81475587/f8d06c58-fc73-4829-9712-76e445be9256">


## 💬 To Reviewers
<!-- 리뷰어들에게 하고 싶은 말 -->
클릭 카운트 6 -> 7 될 때 WordRepository에선 삭제, MemorizedWordRepository에 추가


## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크) -->
